### PR TITLE
fix: use variable for the idle screen message

### DIFF
--- a/modernx.lua
+++ b/modernx.lua
@@ -2277,7 +2277,7 @@ function tick()
             ass:new_event()
             ass:pos(display_w / 2, icon_y + 65)
             ass:an(8)
-            ass:append('Drop files or URLs to play here.')
+            ass:append(texts.welcome)
         end
         set_osd(display_w, display_h, ass.text)
 


### PR DESCRIPTION
I just realized that in commit 064100652794ca258cbbd3c0200578bb0e8d465c I forgot to use the variable for the translated idle screen message