### PR TITLE
Use explicit alignment for thumbnail background

### DIFF
--- a/modernx.lua
+++ b/modernx.lua
@@ -823,6 +823,7 @@ function render_elements(master_ass)
 
                             elem_ass:new_event()
                             elem_ass:pos(thumbX * r_w, ty - thumbMarginY - thumbfast.height * r_h)
+                            elem_ass:an(7)
                             elem_ass:append(osc_styles.Tooltip)
                             elem_ass:draw_start()
                             elem_ass:rect_cw(-thumbPad * r_w, -thumbPad * r_h, (thumbfast.width + thumbPad) * r_w, (thumbfast.height + thumbPad) * r_h)


### PR DESCRIPTION
Some clients do not default ASS alignment to 7, which is what we expect.

This was an issue on 3rd party clients like Syncplay and MPV-EASY. https://github.com/po5/thumbfast/issues/100, https://github.com/po5/thumbfast/issues/81